### PR TITLE
redirect after confirmation bug fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,4 +94,3 @@ gem "hamlit-rails", "~> 0.2.3"
 gem "icodi"
 gem "kaminari"
 gem "ransack", "~> 3.2"
-gem "rubocop", "~> 1.32", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,7 +370,6 @@ DEPENDENCIES
   ransack (~> 3.2)
   redis (~> 4.0)
   rspec-rails (~> 5.1, >= 5.1.2)
-  rubocop (~> 1.32)
   selenium-webdriver
   sprockets-rails
   standard (= 1.14.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,16 +13,15 @@ class ApplicationController < ActionController::Base
   end
 
   def persist_last_visited_path
-    unless Rails.configuration.ignored_paths.include?(request.path)
-      session[:last_visited_path] = request.path
-    end
+    session[:last_visited_path] = request.path unless Rails.configuration.ignored_paths.include?(request.path) || request.path == "/users/confirmation"
   end
 
   def after_sign_in_path_for(resource)
-    if session[:last_visited_path].present?
-      session[:last_visited_path]
-    else
-      root_path
-    end
+    stored_location_for(resource) ||
+      if resource.is_a?(User) && Rails.configuration.ignored_paths.exclude?(request.path)
+        super
+      else
+        session[:last_visited_path].present? ? session[:last_visited_path] : root_path
+      end
   end
 end


### PR DESCRIPTION
Resolves #92

This bug arose after we made the redirect back to where you are coming from after sign in, this broke the confirmation process. This PR fixes that.