### PR TITLE
fix tabs colors

### DIFF
--- a/app/javascript/controllers/tabclick_controller.js
+++ b/app/javascript/controllers/tabclick_controller.js
@@ -5,10 +5,10 @@ export default class extends Controller {
     var tabs = [...document.querySelectorAll(".house-plant-tabs")];
 
     tabs.forEach((tab) => {
-      tab.classList.remove("bg-blue-700");
-      tab.classList.add("bg-emerald-300");
+      tab.classList.remove("bg-emerald-400");
+      tab.classList.add("bg-emerald-200");
     });
-    event.target.classList.remove("bg-emerald-300");
-    event.target.classList.add("bg-blue-700");
+    event.target.classList.remove("bg-emerald-200");
+    event.target.classList.add("bg-emerald-400");
   }
 }

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -9,11 +9,11 @@
     %h2.font-semibold.text-2xl.mb-4 House plants
     %ul.flex.flex-wrap.items-end.text-sm.font-medium.text-center.text-white.border-b-2.border-emerald-600
       %li.mr-2
-        = link_to 'Most Recent', most_recent_plants_path, class: 'house-plant-tabs inline-block p-4 text-black hover:bg-blue-200 bg-blue-700', data: { turbo_frame: 'house_plant_tabs', controller: 'tabclick', action: 'tabclick#swapclass' }
+        = link_to 'Most Recent', most_recent_plants_path, class: 'house-plant-tabs inline-block p-4 text-black hover:underline bg-emerald-400', data: { turbo_frame: 'house_plant_tabs', controller: 'tabclick', action: 'tabclick#swapclass' }
       %li.mr-2
-        = link_to 'Top 10', top_ten_plants_path, class: 'house-plant-tabs inline-block p-4 text-black bg-emerald-300 hover:bg-blue-200', data: { turbo_frame: 'house_plant_tabs', controller: 'tabclick', action: 'tabclick#swapclass' }
+        = link_to 'Top 10', top_ten_plants_path, class: 'house-plant-tabs inline-block p-4 text-black bg-emerald-200 hover:underline', data: { turbo_frame: 'house_plant_tabs', controller: 'tabclick', action: 'tabclick#swapclass' }
       %li.mr-2
-        = link_to 'Categories', plants_category_path, class: 'house-plant-tabs inline-block p-4 text-black bg-emerald-300 hover:bg-blue-200', data: { turbo_frame: 'house_plant_tabs', controller: 'tabclick', action: 'tabclick#swapclass' }
+        = link_to 'Categories', plants_category_path, class: 'house-plant-tabs inline-block p-4 text-black bg-emerald-200 hover:underline', data: { turbo_frame: 'house_plant_tabs', controller: 'tabclick', action: 'tabclick#swapclass' }
       %li.ml-auto
         = search_form_for @q do |f|
           .block.p-3.pr-0.w-full.text-sm.text-gray-900


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54212560/188073141-fa6bebf4-d33a-4176-ba83-f9aa1fed4c8a.png)
instead of:
![image](https://user-images.githubusercontent.com/54212560/188073225-b16f40a1-5e64-4283-9120-2c7729ee0812.png)

I replaced hover background color with underline effect and made active/inactive tabs color more matching.