### PR TITLE
streaming works, auto mark as read on page visit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :persist_last_visited_path
+  before_action :reset_notification_count, if: :current_user
 
   protected
 
@@ -14,6 +15,10 @@ class ApplicationController < ActionController::Base
 
   def persist_last_visited_path
     session[:last_visited_path] = request.path unless Rails.configuration.ignored_paths.include?(request.path) || request.path == "/users/confirmation"
+  end
+
+  def reset_notification_count
+    @unread_count ||= current_user.notifications.not_deleted.unread.count
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -12,7 +12,9 @@ class PlantsController < ApplicationController
     @commentable = @plant
     @comment = Comment.new
     @comments = @plant.comments
-    user_notifications = @plant.comments.flat_map { |comment| comment.notifications_as_comment }
+
+    # Marking user notifications for this plant as read!
+    @plant.comments.flat_map { |comment| comment.notifications_as_comment }
       .filter { |notification| notification.recipient == current_user }
       .map(&:mark_as_read!)
   end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -12,6 +12,10 @@ class PlantsController < ApplicationController
     @commentable = @plant
     @comment = Comment.new
     @comments = @plant.comments
+    user_notifications = @plant.comments.flat_map { |comment| comment.notifications_as_comment  }
+                                .filter { |notification| notification.recipient == current_user }
+                                .map(&:mark_as_read!)
+    
   end
 
   def new

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -12,10 +12,9 @@ class PlantsController < ApplicationController
     @commentable = @plant
     @comment = Comment.new
     @comments = @plant.comments
-    user_notifications = @plant.comments.flat_map { |comment| comment.notifications_as_comment  }
-                                .filter { |notification| notification.recipient == current_user }
-                                .map(&:mark_as_read!)
-    
+    user_notifications = @plant.comments.flat_map { |comment| comment.notifications_as_comment }
+      .filter { |notification| notification.recipient == current_user }
+      .map(&:mark_as_read!)
   end
 
   def new

--- a/app/javascript/controllers/notificationcount_controller.js
+++ b/app/javascript/controllers/notificationcount_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+
+  increasebyone() {
+    var headerCounter = document.querySelector('.notification-count')
+    headerCounter.innerHTML = Number(headerCounter.innerHTML) + 1
+  }
+
+  decreasebyone() {
+    var headerCounter = document.querySelector('.notification-count')
+    headerCounter.innerHTML = Number(headerCounter.innerHTML) - 1
+  }
+}

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,6 +8,8 @@ class Notification < ApplicationRecord
 
   after_create_commit :broadcast_to_recipient
 
+  private
+
   def broadcast_to_recipient
     broadcast_append_later_to(
       recipient,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,4 +5,18 @@ class Notification < ApplicationRecord
   scope :not_deleted, -> { where(deleted_at: nil) }
 
   default_scope { where("deleted_at > ?", 20.seconds.ago).or(where(deleted_at: nil)) }
+
+  after_create_commit :broadcast_to_recipient
+
+  def broadcast_to_recipient
+    broadcast_append_later_to(
+      recipient,
+      :notifications,
+      target: 'notifications-list',
+      partial: 'notifications/notification',
+      locals: {
+        notification: self
+      }
+    )
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -12,8 +12,8 @@ class Notification < ApplicationRecord
     broadcast_append_later_to(
       recipient,
       :notifications,
-      target: 'notifications-list',
-      partial: 'notifications/notification',
+      target: "notifications-list",
+      partial: "notifications/notification",
       locals: {
         notification: self
       }

--- a/app/notifications/comment_notification.rb
+++ b/app/notifications/comment_notification.rb
@@ -18,10 +18,10 @@ class CommentNotification < Noticed::Base
   # Define helper methods to make rendering easier.
   #
   def comment
-    params[:comment].body
+    params[:comment]
   end
 
   def url
-    plant_comment_path(params[:plant][:comment])
+    plant_path(Plant.find(params[:comment].commentable_id))
   end
 end

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -1,16 +1,15 @@
-
-%p.text-gray-700
-  = simple_format notification.to_notification.comment
-    
-.flex.justify-between.mt-1.text-gray-500.text-sm.space-x-4
-  %p
-    Received on #{notification.created_at.to_date}
-  %p
-    - if notification.read?
-      = link_to 'Mark as unread', set_to_unread_path(id: notification.id), class: 'btn-primary bg-blue-500 hover:bg-blue-700 text-white'
-    - elsif notification.unread?
-      = link_to 'Mark as read', set_to_read_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded'
-    - if notification.deleted_at && notification.deleted_at > 15.seconds.ago
-      = link_to 'Undo delete', undelete_notification_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded'
-    - elsif !notification.deleted_at
-      = link_to 'Delete', set_to_deleted_path(id: notification.id), class: 'bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded'
+%li
+  %p.text-gray-700
+    = link_to simple_format(notification.to_notification.comment.body), notification.to_notification.url
+  .flex.justify-between.mt-1.text-gray-500.text-sm.space-x-4
+    %p
+      Received on #{notification.created_at.to_date}
+    %p
+      - if notification.read?
+        = link_to 'Mark as unread', set_to_unread_path(id: notification.id), class: 'btn-primary bg-blue-500 hover:bg-blue-700 text-white'
+      - elsif notification.unread?
+        = link_to 'Mark as read', set_to_read_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded'
+      - if notification.deleted_at && notification.deleted_at > 15.seconds.ago
+        = link_to 'Undo delete', undelete_notification_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded'
+      - elsif !notification.deleted_at
+        = link_to 'Delete', set_to_deleted_path(id: notification.id), class: 'bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded'

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -6,10 +6,10 @@
       Received on #{notification.created_at.to_date}
     %p
       - if notification.read?
-        = link_to 'Mark as unread', set_to_unread_path(id: notification.id), class: 'btn-primary bg-blue-500 hover:bg-blue-700 text-white'
+        = link_to 'Mark as unread', set_to_unread_path(id: notification.id), class: 'btn-primary bg-blue-500 hover:bg-blue-700 text-white', data: { controller: "notificationcount", action: "notificationcount#increasebyone"}
       - elsif notification.unread?
-        = link_to 'Mark as read', set_to_read_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded'
+        = link_to 'Mark as read', set_to_read_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded', data: { controller: "notificationcount", action: "notificationcount#decreasebyone"}
       - if notification.deleted_at && notification.deleted_at > 15.seconds.ago
-        = link_to 'Undo delete', undelete_notification_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded'
+        = link_to 'Undo delete', undelete_notification_path(id: notification.id), class: 'bg-green-500 hover:bg-green-400 text-white font-bold py-2 px-4 border-green-700 hover:border-green-500 rounded', data: { controller: "notificationcount", action: "notificationcount#increasebyone"}
       - elsif !notification.deleted_at
-        = link_to 'Delete', set_to_deleted_path(id: notification.id), class: 'bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded'
+        = link_to 'Delete', set_to_deleted_path(id: notification.id), class: 'bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded', data: { controller: "notificationcount", action: "notificationcount#decreasebyone"}

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -1,3 +1,5 @@
+= turbo_stream_from current_user, :notifications
 = turbo_frame_tag "notifications" do
   .text-3xl.font-serif Notifications
-  = render @notifications
+  %ul#notifications-list
+    = render @notifications

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -14,7 +14,10 @@
 
         .flex.items-center.gap-2
           - if user_signed_in?
-            = link_to "#{tag.span=pluralize(current_user.notifications.not_deleted.unread.count, 'Notification')}" , notifications_path, class: 'btn-primary'
+            = link_to notifications_path do
+              %button.btn-primary
+                %span.mr-2= @unread_count == 1 ? "Notification" : "Notifications"
+                %span.inline-flex.items-center.justify-center.px-2.py-1.text-xs.font-bold.leading-none.text-red-100.bg-red-600.rounded-full= @unread_count >= 6 ? "6+" : @unread_count
             .btn-primary= link_to current_user.email, profile_path(current_user)
             = link_to "Settings", edit_user_registration_path(current_user), class: 'btn-primary'
             .btn-primary= button_to "Exit", destroy_user_session_path, :method => 'delete'

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -17,7 +17,7 @@
             = link_to notifications_path do
               %button.btn-primary
                 %span.mr-2= @unread_count == 1 ? "Notification" : "Notifications"
-                %span.inline-flex.items-center.justify-center.px-2.py-1.text-xs.font-bold.leading-none.text-red-100.bg-red-600.rounded-full= @unread_count >= 6 ? "6+" : @unread_count
+                %span.notification-count.inline-flex.items-center.justify-center.px-2.py-1.text-xs.font-bold.leading-none.text-red-100.bg-red-600.rounded-full= @unread_count
             .btn-primary= link_to current_user.email, profile_path(current_user)
             = link_to "Settings", edit_user_registration_path(current_user), class: 'btn-primary'
             .btn-primary= button_to "Exit", destroy_user_session_path, :method => 'delete'


### PR DESCRIPTION
- [x] Notifications creation is being streamed immediately to online users on the index page.
- [x] Notifications arer being marked as unread immediately a user visits the plant page containing the notification.
- [x] The notifications themselves are now links to the plant on which the comment is made and the link is opened in a new tab.
- [ ] Notification Icon on header not updating automatically on update.