### PR TITLE
Refactor user status and page load optimization

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,19 +3,17 @@
 class HomeController < ApplicationController
   def index
     @q = Plant.ransack(params[:q])
-    @most_recent_plants = Plant.order(created_at: :desc).limit(6)
+    @most_recent_plants = Plant.with_attached_img.order(created_at: :desc).limit(6)
   end
 
   def plants
   end
 
   def people
-    @users = User.order(username: :asc).with_attached_avatar
+    @users = User.with_attached_avatar.order(username: :asc)
   end
 
   def top_growers
-    @growers = User.joins(:plants)
-      .group(:id)
-      .order("COUNT(plants.id) DESC")
+    @growers = User.with_attached_avatar.order(plants_count: :desc).limit(10)
   end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -2,7 +2,7 @@
 
 class PlantsController < ApplicationController
   def index
-    @q = Plant.ransack(params[:q])
+    @q = Plant.with_attached_img.ransack(params[:q])
     @plants = @q.result.order(:latin).page(params[:page]).per(12)
   end
 

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -43,7 +43,7 @@ class PlantsController < ApplicationController
   end
 
   def most_recent_plants
-    @most_recent_plants = Plant.order(created_at: :desc).limit(6)
+    @most_recent_plants = Plant.with_attached_img.order(created_at: :desc).limit(6)
   end
 
   def plants_category

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -52,9 +52,7 @@ class PlantsController < ApplicationController
   end
 
   def top_ten_plants
-    @top_ten_plants = Plant.joins(:users)
-      .group(:id)
-      .order("COUNT(users.id) DESC")
+    @top_ten_plants = Plant.with_attached_img.order(users_count: :desc)
       .limit(10) || Plant.all.sample(10)
   end
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -9,4 +9,10 @@ class ProfileController < ApplicationController
     flash[:error] = "User not found"
     redirect_to root_path
   end
+
+  def update_status
+    @user = User.friendly.find_by_slug(params[:slug])
+    @user.admin? ? @user.regular! : @user.admin!
+    redirect_to profile_path(@user)
+  end
 end

--- a/app/helpers/plants_helper.rb
+++ b/app/helpers/plants_helper.rb
@@ -28,7 +28,7 @@ module PlantsHelper
   def ppl_have
     render_haml <<-HAML
       .text-2xl.py-1.font-semibold.rounded.bg-green-200
-        %span= @plant.users.count
+        %span= @plant.users_count
     HAML
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,7 +4,7 @@
 class Comment < ApplicationRecord
   has_noticed_notifications
 
-  belongs_to :user
+  belongs_to :user, counter_cache: true
   belongs_to :commentable, polymorphic: true, inverse_of: :comments
 
   validates :body, presence: true

--- a/app/models/garden_plant.rb
+++ b/app/models/garden_plant.rb
@@ -2,7 +2,7 @@
 
 class GardenPlant < ApplicationRecord
   belongs_to :user, counter_cache: :plants_count
-  belongs_to :plant #, counter_cache: :users_count
+  belongs_to :plant, counter_cache: :users_count
 
   validates_uniqueness_of :user_id, scope: :plant_id, message: "can only have one type plant in your garden"
 end

--- a/app/models/garden_plant.rb
+++ b/app/models/garden_plant.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class GardenPlant < ApplicationRecord
-  belongs_to :user
-  belongs_to :plant
+  belongs_to :user, counter_cache: :plants_count
+  belongs_to :plant #, counter_cache: :users_count
 
   validates_uniqueness_of :user_id, scope: :plant_id, message: "can only have one type plant in your garden"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   validates :email, presence: true, format: URI::MailTo::EMAIL_REGEXP
   validates :username, presence: true
 
-  enum :status, { regular: 0, admin: 1 }
+  enum :status, {regular: 0, admin: 1}
 
   extend FriendlyId
   friendly_id :slugged_usernames, use: :slugged

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
   validates :email, presence: true, format: URI::MailTo::EMAIL_REGEXP
   validates :username, presence: true
 
+  enum :status, { regular: 0, admin: 1 }
+
   extend FriendlyId
   friendly_id :slugged_usernames, use: :slugged
 

--- a/app/views/home/_people_partial.html.haml
+++ b/app/views/home/_people_partial.html.haml
@@ -13,6 +13,6 @@
       .col-span-2.row-span-3.border-b
         .p-2.italic about
       .flex.flex-col.justify-center.text-center.border-r
-        = pluralize(user.garden_plants.count, "plant")
+        = pluralize(user.plants_count, "plant")
       .flex.flex-col.justify-center.text-center
         = "#{ user.comments_count} comments"

--- a/app/views/home/_people_partial.html.haml
+++ b/app/views/home/_people_partial.html.haml
@@ -15,4 +15,4 @@
       .flex.flex-col.justify-center.text-center.border-r
         = pluralize(user.garden_plants.count, "plant")
       .flex.flex-col.justify-center.text-center
-        = "#{ user.comments.count} comments"
+        = "#{ user.comments_count} comments"

--- a/app/views/profile/show.html.haml
+++ b/app/views/profile/show.html.haml
@@ -1,5 +1,9 @@
-.font-serif.text-2xl.font-extrabold.tracking-tight.text-gray-900 
-  = "Welcome to #{@user.username}'s garden!"
+.flex.flex-wrap.justify-between
+  .font-serif.text-2xl.font-extrabold.tracking-tight.text-gray-900 
+    = "Welcome to #{@user.username}'s garden!"
+  %div
+    - if current_user.admin? && current_user != @user
+      = link_to @user.admin? ? "Remove admin status" : "Make admin", update_status_path(slug: @user), class: 'btn-primary'
 
 .flex.justify-between
   - if user_signed_in?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   }
 
   resources :profile, only: [:show], param: :slug
+  get 'update_status', to: 'profile#update_status'
 
   resources :plants do
     resources :comments, module: :plants
@@ -33,3 +34,4 @@ Rails.application.routes.draw do
   get "set_to_read", to: "notifications#set_to_read"
   get "set_to_unread", to: "notifications#set_to_unread"
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   }
 
   resources :profile, only: [:show], param: :slug
-  get 'update_status', to: 'profile#update_status'
+  get "update_status", to: "profile#update_status"
 
   resources :plants do
     resources :comments, module: :plants
@@ -34,4 +34,3 @@ Rails.application.routes.draw do
   get "set_to_read", to: "notifications#set_to_read"
   get "set_to_unread", to: "notifications#set_to_unread"
 end
-

--- a/db/migrate/20221004095153_change_column_name_on_users.rb
+++ b/db/migrate/20221004095153_change_column_name_on_users.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNameOnUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :admin
+    add_column :users, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20221004133249_add_comments_count_to_user.rb
+++ b/db/migrate/20221004133249_add_comments_count_to_user.rb
@@ -1,0 +1,5 @@
+class AddCommentsCountToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :comments_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20221004133401_populate_users_comments_count.rb
+++ b/db/migrate/20221004133401_populate_users_comments_count.rb
@@ -1,0 +1,7 @@
+class PopulateUsersCommentsCount < ActiveRecord::Migration[7.0]
+  def up
+    User.find_each do |user|
+      User.reset_counters(user.id, :comments)
+    end
+  end
+end

--- a/db/migrate/20221004134018_add_plants_count_to_users.rb
+++ b/db/migrate/20221004134018_add_plants_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddPlantsCountToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :plants_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20221004134047_populate_users_plants_count.rb
+++ b/db/migrate/20221004134047_populate_users_plants_count.rb
@@ -1,0 +1,7 @@
+class PopulateUsersPlantsCount < ActiveRecord::Migration[7.0]
+  def up
+    User.find_each do |user|
+      User.reset_counters(user.id, :garden_plants)
+    end
+  end
+end

--- a/db/migrate/20221004134851_add_users_count_to_plants.rb
+++ b/db/migrate/20221004134851_add_users_count_to_plants.rb
@@ -1,0 +1,5 @@
+class AddUsersCountToPlants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :plants, :users_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20221004134949_populate_plant_users.rb
+++ b/db/migrate/20221004134949_populate_plant_users.rb
@@ -1,0 +1,7 @@
+class PopulatePlantUsers < ActiveRecord::Migration[7.0]
+  def up
+    Plant.find_each do |plant|
+      Plant.reset_counters(plant.id, :garden_plants)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_133401) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_134047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -266,6 +266,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_133401) do
     t.string "uid"
     t.integer "status", default: 0
     t.integer "comments_count", default: 0
+    t.integer "plants_count", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_18_215240) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_095153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -262,9 +262,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_18_215240) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "slug"
-    t.boolean "admin", default: false
     t.string "provider"
     t.string "uid"
+    t.integer "status", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_134047) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_134949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -246,6 +246,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_134047) do
     t.string "category"
     t.string "latin"
     t.string "slug"
+    t.integer "users_count", default: 0
     t.index ["slug"], name: "index_plants_on_slug", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_095153) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_133401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -265,6 +265,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_095153) do
     t.string "provider"
     t.string "uid"
     t.integer "status", default: 0
+    t.integer "comments_count", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
There are many things in play here.

1. after the last N+1 queries refactor exercise, there are some queries that were left out. Those have been included here most especially the activestorage queries.
2. User statuses where initially boolean on the admin column, but this has been migrated to use enum, this way we can have many statuses. 
  2.2 Admin users can make other users an admin, or remove the admin status of a fellow admin. But an admin cannot do this on their own account.

On pages such /people or /top_growers where we require the count of an association but not the records themselves, columns have been created to keep track of association counts on creation and deletion, this in fact reduced the complexity of some of the queries been made to the database.